### PR TITLE
Add a way to specify a custom move function

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@ Or install it yourself as:
 
 ## Usage
 
-To use this gem, you must have an object that implements a `distance` method or a lambda function where you calculate the total energy of an enumerable object.
+To use this gem, you must provide a lambda function to calculate the total energy of an object, and a way to change the state of the object to a neighboring state.
 
-Lets solve the traveling salesman, for that we will need an object with a distance method
-to mesure the distance between two locations.
+Lets solve the traveling salesman problem. First we will need an object with a distance method to measure the distance between two locations.
 
 ```ruby
 Location = Struct.new(:x, :y) do
@@ -40,7 +39,7 @@ Location = Struct.new(:x, :y) do
 end
 ```
 
-Now we can create an array of the locations
+Now we can create an array of locations the salesperson will visit. This is our initial state, and the order can be any random starting state.
 
 ```ruby
 locations = [
@@ -49,57 +48,115 @@ locations = [
   Location.new(40, 120),
   Location.new(100, 120),
   Location.new(20, 40)
-]
+].shuffle
 ```
 
-Now we can just pass the locations argumen.
+Next we need a way to calculate the total energy of traveling to each location in turn. Think of it as a representation of the efficiency of the trip; the further away one point is away from the next, the less efficient the trip is.
 
 ```ruby
-puts Annealing.simulate(locations)
-[(20,40), (40,120), (100,120), (60,200), (180,200)]
-```
-
-This will run the simulation with the default parameters and it could take a while to finish.
-But if you want to iterate with other parameters you can send the parameters `temperature` and `cooling_rate`.
-
-```ruby
-simulator = Annealing::Simulator.new(temperature: 10_000, cooling_rate: 0.5)
-solution = simulator.run(locations)
-solution.energy
-351.901234
-solution.collection
-[(20,40), (40,120), (100,120), (60,200), (180,200)]
-```
-
-You can also configure the default parameters
-
-```ruby
-Annealing.configure do |c|
-  c.temperature  = 10_000.0
-  c.cooling_rate = 0.003
-end
-```
-
-### Custom total energy calculator
-
-You can set a lambda function to customize the total energy in a collection by setting in the default parameters
-
-```ruby
-Annealing.configure do |c|
-  c.total_energy_calculator = lambda do |enumerable|
-    enumerable.each_cons(2).sum { |a, b| a.distance(b) }
+energy_calculator = -> (locations) do
+  locations.each_cons(2).sum do |location1, location2|
+    location1.distance(location2)
   end
 end
 ```
 
-or in the simulator as a parameter
+Finally, we need a way to make small, random changes the order of the locations the salesperson will visit as we probe for the most efficient route.
 
 ```ruby
-calc = lambda do |enumerable|
-  enumerable.each_cons(2).sum { |a, b| a.distance(b) }
+state_change = -> (locations) do
+  size = locations.size
+  swapped = locations.dup
+  idx_a = rand(size)
+  idx_b = rand(size)
+  swapped[idx_b], swapped[idx_a] = swapped[idx_a], swapped[idx_b]
+  swapped
 end
-solution = simulator.run(locations, calc).collection
-[(20,40), (40,120), (100,120), (60,200), (180,200)]
+```
+
+Now we can just pass the locations argument as the initial state and let the annealer search for the most efficient route. This will run the simulation with the default temperature and cooling rate, which could take a while to finish.
+
+```ruby
+simulator = Annealing::Simulator.new
+solution = simulator.run(locations,
+                         energy_calculator: energy_calculator,
+                         state_change: state_change)
+solution.state
+# => [(20,40), (40,120), (100,120), (60,200), (180,200)]
+```
+
+If you want to iterate with other parameters you can send the parameters `temperature` and `cooling_rate`.
+
+```ruby
+simulator = Annealing::Simulator.new(temperature: 10_000, cooling_rate: 0.5)
+solution = simulator.run(locations,
+                         energy_calculator: energy_calculator,
+                         state_change: state_change)
+solution.energy
+# => 351.901234
+solution.state
+# => [(20,40), (40,120), (100,120), (60,200), (180,200)]
+```
+
+## Configuration
+
+You can set default parameters that will be used in every simulation. For instance, we can rewrite the previous example like so:
+
+```ruby
+Annealing.configure do |c|
+  c.temperature  = 10_000
+  c.cooling_rate = 0.5
+  c.energy_calculator = -> (locations) do
+    locations.each_cons(2).sum do |location1, location2|
+      location1.distance(location2)
+    end
+  end
+  c.state_change = -> (locations) do
+    size = locations.size
+    swapped = locations.dup
+    idx_a = rand(size)
+    idx_b = rand(size)
+    swapped[idx_b], swapped[idx_a] = swapped[idx_a], swapped[idx_b]
+    swapped
+  end
+end
+
+solution = Annealing.simulate(locations)
+```
+
+Note that `energy_calculator` and `state_change` can be any object that responds to `#call` and accepts a single argument which is the current state being measured or moved. This allows for lots of flexibility. For instance, you could use a custom calculator class that takes into account some other external factor:
+
+```ruby
+class PotentialSalesCalculator
+  def initialize(initial_time_of_day)
+    @initial_time_of_day = initial_time_of_day
+  end
+
+  def energy(locations)
+    arrival_time = @initial_time_of_day
+    first_location_sales = potential_sales(locations.first, arrival_time)
+    locations.each_cons(2).sum do |location1, location2|
+      arrival_time += travel_time(location1, location2, arrival_time)
+      distance = location1.distance(location2)
+      potential_sales(locations.first, arrival_time) / distance
+    end + first_location_sales
+  end
+
+  def potential_sales(location, time_of_day)
+    habits = CustomerHabits.new(location)
+    customers = habits.whos_home_at(time_of_day)
+    SalesTrends.estimate(customers)
+  end
+
+  def travel_time(location1, location2, time_of_day)
+    traffic = TrafficPredictor.new(location1, location2)
+    traffic.travel_time(time_of_day)
+  end
+end
+
+calculator = PotentialSalesCalculator.new(8)
+simulator = Annealing::Simulator.new
+solution = simulator.run(locations, energy_calculator: calculator.method(:energy))
 ```
 
 ## Development

--- a/bin/run
+++ b/bin/run
@@ -4,27 +4,54 @@
 require 'bundler/setup'
 require 'annealing'
 
-Location = Struct.new(:x, :y) do
+Location = Struct.new(:name, :x, :y) do
   def inspect
-    "(#{x},#{y})"
+    "#{name} (#{x},#{y})"
   end
 
   def distance(location)
-    dx = x - location.x
-    dy = y - location.y
-    (dx * dx) + (dy * dy)
+    dx = (x - location.x).abs
+    dy = (y - location.y).abs
+    Math.sqrt(dx**2 + dy**2)
   end
 end
 
-simulator = Annealing::Simulator.new(temperature: 10_000, cooling_rate: 0.01)
-collection = [
-  Location.new(60, 200),
-  Location.new(180, 200),
-  Location.new(40, 120),
-  Location.new(100, 120),
-  Location.new(20, 40)
-]
-result = simulator.run(collection)
+locations = [
+  Location.new('Blaire Hills', 60, 200),
+  Location.new('Smallville', 180, 200),
+  Location.new('Boggs Harbor', 40, 120),
+  Location.new('Curtisville', 100, 120),
+  Location.new('Allentown', 20, 40)
+].shuffle
 
-puts result.energy
-puts result.collection
+energy_calculator = -> (locations) do
+  locations.each_cons(2).sum do |location1, location2|
+    location1.distance(location2)
+  end
+end
+
+state_change = -> (locations) do
+  size = locations.size
+  swapped = locations.dup
+  idx_a = rand(size)
+  idx_b = rand(size)
+  swapped[idx_b], swapped[idx_a] = swapped[idx_a], swapped[idx_b]
+  swapped
+end
+
+simulator = Annealing::Simulator.new(temperature: 10_000, cooling_rate: 0.01)
+solution = simulator.run(locations,
+                         energy_calculator: energy_calculator,
+                         state_change: state_change)
+
+puts "\nInitial itinerary:"
+locations.each_cons(2).each_with_index do |(location1, location2), index|
+  puts "Stop ##{index + 1}: #{location1.name} -> #{location2.name} (#{location1.distance(location2)})"
+end
+puts "-------\nEnergy: #{energy_calculator.call(locations)}"
+
+puts "\nAnnealed itinerary:"
+solution.state.each_cons(2).each_with_index do |(location1, location2), index|
+  puts "Stop ##{index + 1}: #{location1.name} -> #{location2.name} (#{location1.distance(location2)})"
+end
+puts "-------\nEnergy: #{solution.energy}"

--- a/lib/annealing.rb
+++ b/lib/annealing.rb
@@ -23,11 +23,9 @@ module Annealing
     yield(configuration)
   end
 
-  def self.simulate(collection)
-    return [] if collection.empty?
-
+  def self.simulate(initial_state)
     simulator = Simulator.new
-    simulator.run(collection).collection
+    simulator.run(initial_state).state
   end
 
   def self.logger

--- a/lib/annealing/configuration.rb
+++ b/lib/annealing/configuration.rb
@@ -3,17 +3,19 @@
 module Annealing
   # It enables the gem configuration
   class Configuration
-    attr_accessor :temperature, :cooling_rate, :total_energy_calculator, :logger
+    attr_accessor :temperature, :cooling_rate, :logger,
+                  :energy_calculator, :state_change
 
     def initialize
+      reset
+    end
+
+    def reset
       @temperature  = 10_000.0
       @cooling_rate = 0.0003
-      @total_energy_calculator = lambda do |enumerable|
-        enumerable.each_cons(2).sum do |value_a, value_b|
-          value_a.distance(value_b)
-        end
-      end
       @logger = Logger.new(STDOUT)
+      @energy_calculator = nil
+      @state_change = nil
     end
   end
 end

--- a/lib/annealing/simulator.rb
+++ b/lib/annealing/simulator.rb
@@ -14,8 +14,10 @@ module Annealing
       normalize_cooling_rate
     end
 
-    def run(collection, calculator = nil)
-      current = Metal.new(collection.shuffle, calculator)
+    def run(initial_state, energy_calculator: nil, state_change: nil)
+      current = Metal.new(initial_state,
+                          energy_calculator: energy_calculator,
+                          state_change: state_change)
       Annealing.logger.debug(" Original: #{current}")
       cool_down do |temp|
         current = current.cooled(temp)

--- a/test/annealing/simulator_test.rb
+++ b/test/annealing/simulator_test.rb
@@ -4,33 +4,56 @@ require 'test_helper'
 
 module Annealing
   class SimulatorTest < Minitest::Test
-    def collection
-      [
-        Location.new(60, 200),
-        Location.new(180, 200),
-        Location.new(40, 120),
-        Location.new(100, 120),
-        Location.new(20, 40)
+    def setup
+      @locations = [
+        Location.new(3, 3),
+        Location.new(1, 1),
+        Location.new(4, 4),
+        Location.new(5, 5),
+        Location.new(2, 2)
       ]
+
+      @energy_calculator = -> (locations) do
+        locations.each_cons(2).sum do |location1, location2|
+          location1.distance(location2)
+        end
+      end
+
+      Annealing.configure do |config|
+        config.energy_calculator = @energy_calculator
+        config.state_change = -> (locations) do
+          size = locations.size
+          swapped = locations.dup
+          idx_a = rand(size)
+          idx_b = rand(size)
+          swapped[idx_b], swapped[idx_a] = swapped[idx_a], swapped[idx_b]
+          swapped
+        end
+      end
+
+      @simulator = Simulator.new(temperature: 10_000, cooling_rate: 0.01)
     end
 
-    def simulator
-      Simulator.new(temperature: 10_000, cooling_rate: 0.01)
+    def teardown
+      Annealing.configuration.reset
     end
 
     def test_run
-      simulation = simulator.run(collection)
-      assert simulation.energy < 33_000
+      initial_energy = @energy_calculator.call(@locations)
+      assert_equal 46, initial_energy
+      simulation = @simulator.run(@locations)
+      assert_operator simulation.energy, :<, initial_energy
     end
 
-    def calc_lambda
-      ->(c) { c.each_with_index.sum { |x, i| 2**(x - i) } }
-    end
-
-    def test_run_with_custom_calc
-      arr = (1..10).to_a.shuffle
-      simulation = simulator.run(arr, calc_lambda)
-      assert simulation.energy <= 22
+    def test_run_with_calc_and_move_override
+      initial_state = rand * 16
+      energy_calculator = -> (state) { state * state - 16 }
+      state_change = -> (state) { state + (rand - 0.5) }
+      initial_energy = energy_calculator.call(initial_state)
+      simulation = @simulator.run(initial_state,
+                                  energy_calculator: energy_calculator,
+                                  state_change: state_change)
+      assert_operator simulation.energy, :<, initial_energy
     end
   end
 end


### PR DESCRIPTION
## What

Implements the first proposed change in https://github.com/3zcurdia/annealing_rb/issues/1

## Why

`Metal#swap_collection` assumes that the collection is a singe-dimension array and a neighboring state can be found by swapping elements. In my case, I'm working with a two dimensional array and neighboring states are created from shifting elements of one internal array to another. There are likely other use cases that might call for more complicated object manipulations. Being able to specify a custom move function that receives the current state and returns the next state would allow this library to be able to anneal more complex objects.

## How

- Remove assumption that initial state will be an enumerable. It is now referred to as `state` rather than `collection`
- Rename `total_energy_calculator` to `energy_calculator` for brevity and consistency
- Remove default `energy_calculator` lambda. It assumed a collection of `Location` objects. Users must now specify their own `energy_calculator` function based on the object they are annealing.
- Adds the ability to specify a custom `state_change` method, replacing `Metal#swap_collection`. Users must specify their own `state_change` function based on the object they are annealing.
- Changes the signature of some methods to use kwargs instead of positional arguments, making it easier to pass in custom `energy_calculator` or `state_change` functions
- Standardizes some variable names
- Updates to documentation and example `bin/run` script 

Note that the original proposal was: 

> Add a way to specify a custom move function _that defaults to what `Metal#swap_collection` does now_"

I purposely chose not to default to the previous implementation of `Metal#swap_collection` as that assumed that the initial state was an enumerable, which it isn't guaranteed to be. IMO it's better that we require the user to provide their own method based on whatever object they are annealing.