### PR TITLE
Metal has temperature

### DIFF
--- a/lib/annealing/simulator.rb
+++ b/lib/annealing/simulator.rb
@@ -17,7 +17,7 @@ module Annealing
     def run(initial_state, energy_calculator: nil, state_change: nil, termination_condition: nil)
       termination_condition ||= default_termination_condition
 
-      current = Metal.new(initial_state,
+      current = Metal.new(initial_state, @temperature,
                           energy_calculator: energy_calculator,
                           state_change: state_change)
       Annealing.logger.debug("Original: #{current}")

--- a/test/annealing/metal_test.rb
+++ b/test/annealing/metal_test.rb
@@ -21,7 +21,7 @@ module Annealing
       # when a global energy_calculator has not been defined
       Annealing.configuration.energy_calculator = nil
       assert_raises(ArgumentError, 'Missing energy calculator function') do
-        Annealing::Metal.new(nil)
+        Annealing::Metal.new(@collection, @temperature)
       end
     end
 
@@ -29,47 +29,53 @@ module Annealing
       # when a global state_change function has not been defined
       Annealing.configuration.state_change = nil
       assert_raises(ArgumentError, 'Missing state change function') do
-        Annealing::Metal.new(nil)
+        Annealing::Metal.new(@collection, @temperature)
       end
     end
 
     def test_energy_calls_energy_calculator_with_current_state
       custom_calculator = MiniTest::Mock.new
       custom_calculator.expect(:call, 42, [@collection])
-      metal = Annealing::Metal.new(@collection,
+      metal = Annealing::Metal.new(@collection, @temperature,
                                    energy_calculator: custom_calculator)
       assert_equal 42, metal.energy
     end
 
-    def test_cooled_returns_metal_instance
-      metal = Annealing::Metal.new(@collection)
-      cooled_metal = metal.cooled(@temperature)
+    def test_cooled_returns_metal_instance_with_new_temperature
+      metal = Annealing::Metal.new(@collection, @temperature)
+      new_temperature = @temperature - 1
+      cooled_metal = metal.cooled(new_temperature)
       assert_instance_of Annealing::Metal, cooled_metal
+      assert_equal new_temperature, cooled_metal.temperature
     end
 
     def test_cooled_calls_state_change_function_with_current_state
       custom_state_changer = MiniTest::Mock.new
       custom_state_changer.expect(:call, [], [@collection])
-      metal = Annealing::Metal.new(@collection,
+      metal = Annealing::Metal.new(@collection, @temperature,
                                    state_change: custom_state_changer)
       metal.cooled(@temperature)
       custom_state_changer.verify
     end
 
     def test_cooled_returns_cooled_metal_when_better_than
-      metal = Annealing::Metal.new(@collection)
+      metal = Annealing::Metal.new(@collection, @temperature)
+      new_temperature = @temperature - 1
       cooled_metal = metal.stub(:better_than?, true) do
-        metal.cooled(@temperature)
+        metal.cooled(new_temperature)
       end
       refute_same metal, cooled_metal
+      refute_equal new_temperature, metal.temperature
     end
 
     def test_cooled_returns_the_original_metal_when_not_better_than
-      metal = Annealing::Metal.new(@collection)
+      metal = Annealing::Metal.new(@collection, @temperature)
+      new_temperature = @temperature - 1
       cooled_metal = metal.stub(:better_than?, false) do
-        metal.cooled(@temperature)
+        metal.cooled(new_temperature)
       end
       assert_same metal, cooled_metal
+      assert_equal new_temperature, metal.temperature
     end
 
     def test_better_than_calls_energy_calculator_on_cooled_state
@@ -79,21 +85,21 @@ module Annealing
       custom_calculator.expect(:call, @current_energy, [@collection])
       custom_calculator.expect(:call, cooled_energy, [changed_collection])
 
-      metal = Annealing::Metal.new(@collection,
+      metal = Annealing::Metal.new(@collection, @temperature,
                                    energy_calculator: custom_calculator)
-      cooled_metal = Annealing::Metal.new(changed_collection,
+      cooled_metal = Annealing::Metal.new(changed_collection, @temperature,
                                           energy_calculator: custom_calculator)
-      metal.better_than?(cooled_metal, @temperature)
+      metal.better_than?(cooled_metal)
       custom_calculator.verify
     end
 
     def test_better_than_returns_true_when_positive_difference_between_energies
       cooled_energy = @current_energy / 2
-      metal = Annealing::Metal.new(@collection)
-      cooled_metal = Annealing::Metal.new(@collection.shuffle)
+      metal = Annealing::Metal.new(@collection, @temperature)
+      cooled_metal = Annealing::Metal.new(@collection.shuffle, @temperature)
       metal.stub(:energy, @current_energy) do
         cooled_metal.stub(:energy, cooled_energy) do
-          assert metal.better_than?(cooled_metal, @temperature)
+          assert metal.better_than?(cooled_metal)
         end
       end
     end
@@ -101,12 +107,12 @@ module Annealing
     def test_better_than_true_when_negative_energy_delta_zero_probability
       cooled_energy = @current_energy * 2
       probability = 0
-      metal = Annealing::Metal.new(@collection)
-      cooled_metal = Annealing::Metal.new(@collection.shuffle)
+      metal = Annealing::Metal.new(@collection, @temperature)
+      cooled_metal = Annealing::Metal.new(@collection.shuffle, @temperature)
       metal.stub(:energy, @current_energy) do
         cooled_metal.stub(:energy, cooled_energy) do
           metal.stub(:rand, probability) do
-            assert metal.better_than?(cooled_metal, @temperature)
+            assert metal.better_than?(cooled_metal)
           end
         end
       end
@@ -115,12 +121,12 @@ module Annealing
     def test_better_than_false_when_negative_energy_delta_nonzero_probability
       cooled_energy = @current_energy * 2
       probability = 1
-      metal = Annealing::Metal.new(@collection)
-      cooled_metal = Annealing::Metal.new(@collection.shuffle)
+      metal = Annealing::Metal.new(@collection, @temperature)
+      cooled_metal = Annealing::Metal.new(@collection.shuffle, @temperature)
       metal.stub(:energy, @current_energy) do
         cooled_metal.stub(:energy, cooled_energy) do
           metal.stub(:rand, probability) do
-            refute metal.better_than?(cooled_metal, @temperature)
+            refute metal.better_than?(cooled_metal)
           end
         end
       end


### PR DESCRIPTION
I was starting to work on the final improvement suggested in #1 which is to add a custom cooling function. I kept finding that it wasn't possible to verify how the temperature was changing over time directly and could only verify how many times unrelated functions were called which isn't as direct of a test as I'd prefer. What would be helpful is if I had a way to verify the temperature before and after annealing, and it occurred to me that in physical annealing metal has a temperature at any given stage of the annealing process, so perhaps `Metal` should know it's own temperature at any given stage in the simulated annealing process. 

This adds a `Metal#temperature` attribute. When a new Metal instance is instantiated it receives the current temperature. When the instance is `cooled` to a new temperature and we decide whether to accept the new state or the current state, that state's temperature will be set to the new temperature. I can use this change to improve test coverage for the `Simulator` class as I add the custom cooling function. It can also be useful in practice to measure the effectiveness and efficiency of different simulation strategies.