### PR TITLE
Custom cooling function

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,5 +25,8 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Max: 25
 
+Minitest/MultipleAssertions:
+  Max: 4
+
 Lint/RaiseException:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in annealing.gemspec
 gemspec
 
+gem 'debug', '>= 1.0.0', require: false
 gem 'minitest', '~> 5.0'
 gem 'rake', '~> 13.0', '>= 13.0.6'
 gem 'rubocop', '~> 1.23'
 gem 'rubocop-minitest', '~> 0.17.0'
 gem 'rubocop-performance', '~> 1.12'
 gem 'rubocop-rake', '~> 0.6.0'
-gem 'debug', '>= 1.0.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'rubocop', '~> 1.23'
 gem 'rubocop-minitest', '~> 0.17.0'
 gem 'rubocop-performance', '~> 1.12'
 gem 'rubocop-rake', '~> 0.6.0'
+gem 'debug', '>= 1.0.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    debug (1.4.0)
+      irb (>= 1.3.6)
+      reline (>= 0.2.7)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     minitest (5.14.4)
     parallel (1.21.0)
     parser (3.0.3.2)
@@ -14,6 +20,8 @@ GEM
     rainbow (3.0.0)
     rake (13.0.6)
     regexp_parser (2.2.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rubocop (1.23.0)
       parallel (~> 1.10)
@@ -42,6 +50,7 @@ PLATFORMS
 
 DEPENDENCIES
   annealing!
+  debug (>= 1.0.0)
   minitest (~> 5.0)
   rake (~> 13.0, >= 13.0.6)
   rubocop (~> 1.23)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ simulator = Annealing::Simulator.new
 solution = simulator.run(locations, energy_calculator: calculator.method(:energy))
 ```
 
+### Setting a simulation cool down function
+
+By default, the simulation will decrease the `temperature` linearly by `cooling_rate` on each step of the annealing process. In some cases you may wish to override this to use a different temperature reduction algorithm or to hold the temperature at a certain position until another condition is met. To do so, you can specify a `cool_down` object that responds to `#call`. It can be set globally or per simulation, and it should accept three arguments: the `energy` calculation of the current object, the current `temperature` of the annealer, the `cooling_rate` for the simulation, and the number of `steps` the annealer has taken so far.
+
+```ruby
+# Reduce temperature exponentially
+cool_down = lambda do |_energy, temperature, cooling_rate, steps|
+  temperature - (cooling_rate * (steps**2))
+end
+
+simulator = Annealing::Simulator.new
+solution = simulator.run(some_collection, cool_down: cool_down)
+solution.state
+```
+
 ### Setting a simulation termination condition
 
 Typically, annealing simulators are tasked with finding "close enough" solutions to complex problems by continuously comparing new permutations of an object against one other as the temperature slowly drops to 0 and then returning the lowest energy configuration it found. However, sometimes "close enough" can be determined by other factors as well. For this reason, you might specify a termination condition that will stop the annealing process as soon as the "good enough" condition is met regardless of the current temperature.

--- a/lib/annealing/configuration.rb
+++ b/lib/annealing/configuration.rb
@@ -12,13 +12,25 @@ module Annealing
     end
 
     def reset
-      @cool_down = nil
+      @cool_down = method(:default_cool_down_function)
       @cooling_rate = 0.0003
       @energy_calculator = nil
       @logger = Logger.new($stdout, level: Logger::INFO)
       @state_change = nil
       @temperature  = 10_000.0
-      @termination_condition = nil
+      @termination_condition = method(:default_termination_condition)
+    end
+
+    private
+
+    # Reduce the temperature linearly
+    def default_cool_down_function(_energy, temperature, cooling_rate, _steps)
+      temperature - cooling_rate
+    end
+
+    # Terminate the simulation as soon as the temperature reaches 0
+    def default_termination_condition(_state, _energy, temperature)
+      temperature <= 0.0
     end
   end
 end

--- a/lib/annealing/configuration.rb
+++ b/lib/annealing/configuration.rb
@@ -3,19 +3,21 @@
 module Annealing
   # It enables the gem configuration
   class Configuration
-    attr_accessor :temperature, :cooling_rate, :logger,
-                  :energy_calculator, :state_change, :termination_condition
+    attr_accessor :cool_down, :cooling_rate, :energy_calculator,
+                  :logger, :state_change, :temperature,
+                  :termination_condition
 
     def initialize
       reset
     end
 
     def reset
-      @temperature  = 10_000.0
+      @cool_down = nil
       @cooling_rate = 0.0003
-      @logger = Logger.new($stdout, level: Logger::INFO)
       @energy_calculator = nil
+      @logger = Logger.new($stdout, level: Logger::INFO)
       @state_change = nil
+      @temperature  = 10_000.0
       @termination_condition = nil
     end
   end

--- a/lib/annealing/metal.rb
+++ b/lib/annealing/metal.rb
@@ -8,10 +8,8 @@ module Annealing
     def initialize(state, temperature, energy_calculator: nil, state_change: nil)
       @state = state
       @temperature = temperature
-      @energy_calculator = energy_calculator ||
-                           Annealing.configuration.energy_calculator
-      @state_change = state_change ||
-                      Annealing.configuration.state_change
+      @energy_calculator = energy_calculator || default_energy_calculator
+      @state_change = state_change || default_state_change
 
       raise(ArgumentError, 'Missing energy calculator function') unless @energy_calculator.respond_to?(:call)
 
@@ -52,6 +50,14 @@ module Annealing
       Metal.new(next_state, new_temperature,
                 energy_calculator: @energy_calculator,
                 state_change: @state_change)
+    end
+
+    def default_energy_calculator
+      Annealing.configuration.energy_calculator
+    end
+
+    def default_state_change
+      Annealing.configuration.state_change
     end
   end
 end

--- a/lib/annealing/simulator.rb
+++ b/lib/annealing/simulator.rb
@@ -3,7 +3,7 @@
 module Annealing
   # It runs simulated annealing
   class Simulator
-    attr_reader :temperature, :cooling_rate
+    attr_reader :cooling_rate, :temperature
 
     def initialize(temperature: nil, cooling_rate: nil)
       @temperature = (temperature || default_temperature).to_f
@@ -14,14 +14,22 @@ module Annealing
       raise(ArgumentError, 'Invalid initial cooling rate') if @cooling_rate.negative?
     end
 
-    def run(initial_state, energy_calculator: nil, state_change: nil, termination_condition: nil)
+    def run(initial_state, cool_down: nil, energy_calculator: nil, state_change: nil, termination_condition: nil)
+      cool_down ||= default_cool_down
       termination_condition ||= default_termination_condition
+
+      raise(ArgumentError, 'Missing cool down function') unless cool_down.respond_to?(:call)
+
+      raise(ArgumentError, 'Missing termination condition function') unless termination_condition.respond_to?(:call)
+
       current = Metal.new(initial_state, @temperature,
                           energy_calculator: energy_calculator,
                           state_change: state_change)
       Annealing.logger.debug("Original: #{current}")
-      until termination_condition_met?(termination_condition, current) do
-        current = cool_down(current)
+      steps = 0
+      until termination_condition_met?(termination_condition, current)
+        steps += 1
+        current = reduce_temperature(cool_down, current, steps)
       end
       Annealing.logger.debug("Optimized: #{current}")
       current
@@ -29,17 +37,14 @@ module Annealing
 
     private
 
-    def cool_down(current)
-      current.cooled(current.temperature - cooling_rate)
+    def reduce_temperature(cool_down, metal, steps)
+      new_temperature = cool_down.call(metal.energy, metal.temperature,
+                                       cooling_rate, steps)
+      metal.cooled(new_temperature)
     end
 
     def termination_condition_met?(termination_condition, metal)
-      # binding.break if metal.temperature <= 1
-      if termination_condition.respond_to?(:call)
-        termination_condition.call(metal.state, metal.energy, metal.temperature)
-      else
-        metal.temperature <= 0.0
-      end
+      termination_condition.call(metal.state, metal.energy, metal.temperature)
     end
 
     def default_temperature
@@ -48,6 +53,10 @@ module Annealing
 
     def default_cooling_rate
       Annealing.configuration.cooling_rate
+    end
+
+    def default_cool_down
+      Annealing.configuration.cool_down
     end
 
     def default_termination_condition

--- a/lib/annealing/simulator.rb
+++ b/lib/annealing/simulator.rb
@@ -11,7 +11,7 @@ module Annealing
 
       raise(ArgumentError, 'Invalid initial temperature') if @temperature.negative?
 
-      normalize_cooling_rate
+      raise(ArgumentError, 'Invalid initial cooling rate') if @cooling_rate.negative?
     end
 
     def run(initial_state, energy_calculator: nil, state_change: nil, termination_condition: nil)
@@ -30,12 +30,7 @@ module Annealing
     private
 
     def cool_down(current)
-      # Use addition because cooling rate is negative
-      current.cooled(current.temperature + cooling_rate)
-    end
-
-    def normalize_cooling_rate
-      @cooling_rate = -1.0 * cooling_rate if cooling_rate.positive?
+      current.cooled(current.temperature - cooling_rate)
     end
 
     def termination_condition_met?(termination_condition, metal)

--- a/test/annealing/configuration_test.rb
+++ b/test/annealing/configuration_test.rb
@@ -8,10 +8,6 @@ module Annealing
       @configuration = Annealing::Configuration.new
     end
 
-    def test_sets_the_default_temperature
-      assert_in_delta 10_000.0, @configuration.temperature
-    end
-
     def test_sets_the_default_cooling_rate
       assert_in_delta 0.0003, @configuration.cooling_rate
     end
@@ -22,7 +18,15 @@ module Annealing
       assert_equal Logger::INFO, @configuration.logger.level
     end
 
-    def test_does_not_set_a_default_energy_calculator
+    def test_sets_the_default_temperature
+      assert_in_delta 10_000.0, @configuration.temperature
+    end
+
+    def test_does_not_set_a_default_cool_down_function
+      assert_nil @configuration.cool_down
+    end
+
+    def test_does_not_set_a_default_energy_calculator_function
       assert_nil @configuration.energy_calculator
     end
 
@@ -30,7 +34,7 @@ module Annealing
       assert_nil @configuration.state_change
     end
 
-    def test_does_not_set_a_default_termination_condition
+    def test_does_not_set_a_default_termination_condition_function
       assert_nil @configuration.termination_condition
     end
   end

--- a/test/annealing/configuration_test.rb
+++ b/test/annealing/configuration_test.rb
@@ -8,6 +8,12 @@ module Annealing
       @configuration = Annealing::Configuration.new
     end
 
+    def test_sets_a_default_linear_cool_down_function
+      cool_down = @configuration.cool_down
+      assert_respond_to cool_down, :call
+      assert_equal 1, cool_down.call(nil, 2, 1, nil)
+    end
+
     def test_sets_the_default_cooling_rate
       assert_in_delta 0.0003, @configuration.cooling_rate
     end
@@ -22,8 +28,12 @@ module Annealing
       assert_in_delta 10_000.0, @configuration.temperature
     end
 
-    def test_does_not_set_a_default_cool_down_function
-      assert_nil @configuration.cool_down
+    def test_sets_a_default_termination_condition_function
+      termination_condition = @configuration.termination_condition
+      assert_respond_to termination_condition, :call
+      refute termination_condition.call(nil, nil, 1)
+      assert termination_condition.call(nil, nil, 0)
+      assert termination_condition.call(nil, nil, -1)
     end
 
     def test_does_not_set_a_default_energy_calculator_function
@@ -32,10 +42,6 @@ module Annealing
 
     def test_does_not_set_a_default_state_change_function
       assert_nil @configuration.state_change
-    end
-
-    def test_does_not_set_a_default_termination_condition_function
-      assert_nil @configuration.termination_condition
     end
   end
 end

--- a/test/annealing/simulator_test.rb
+++ b/test/annealing/simulator_test.rb
@@ -27,15 +27,21 @@ module Annealing
       assert_kind_of Float, @simulator.temperature
     end
 
-    def test_forces_cooling_rate_to_negative_float
+    def test_forces_cooling_rate_to_float
       refute_kind_of Float, @cooling_rate
-      assert_equal @cooling_rate.to_f * -1, @simulator.cooling_rate
+      assert_equal @cooling_rate.to_f, @simulator.cooling_rate
       assert_kind_of Float, @simulator.cooling_rate
     end
 
     def test_raises_an_error_if_the_temperature_is_negative
       assert_raises(ArgumentError, 'Invalid initial temperature') do
         Annealing::Simulator.new(temperature: @temperature * -1)
+      end
+    end
+
+    def test_raises_an_error_if_the_cooling_rate_is_negative
+      assert_raises(ArgumentError, 'Invalid initial cooling rate') do
+        Annealing::Simulator.new(cooling_rate: @cooling_rate * -1)
       end
     end
 

--- a/test/annealing/simulator_test.rb
+++ b/test/annealing/simulator_test.rb
@@ -39,10 +39,46 @@ module Annealing
       end
     end
 
-    def test_uses_the_global_energy_calculator_and_state_change_method
+    def test_runs_simulation_until_temperature_reaches_zero_by_default
+      final_state = Annealing::Simulator.new.run(@collection)
+      assert_equal 0, final_state.temperature
+    end
+
+    def test_returns_early_if_global_termination_condition_is_met
+      Annealing.configure do |config|
+        # Exit after the temp drops 10 steps
+        config.termination_condition = lambda do |_state, _energy, temperature|
+          temperature == @temperature - 10
+        end
+      end
+
+      final_state = Annealing::Simulator.new.run(@collection)
+      assert_equal @temperature - 10, final_state.temperature
+    end
+
+    def test_can_override_the_global_termination_condition
+      Annealing.configure do |config|
+        config.termination_condition = lambda do |_state, _energy, temperature|
+          temperature == @temperature - 10
+        end
+      end
+
+      # Exit after the temp drops 20 steps
+      local_termination_condition = lambda do |_state, _energy, temperature|
+        temperature == @temperature - 20
+      end
+
+      simulator = Annealing::Simulator.new
+      final_state = simulator.run(
+        @collection,
+        termination_condition: local_termination_condition)
+      assert_equal @temperature - 20, final_state.temperature
+    end
+
+    def test_uses_global_energy_calculator_and_state_change_functions_by_default
       global_energy_calculator = MiniTest::Mock.new
       global_state_changer = MiniTest::Mock.new
-      (@total_iterations + 1).times do
+      @total_iterations.times do
         global_energy_calculator.expect(:call, 42, [@collection])
         global_state_changer.expect(:call, @collection, [@collection])
       end
@@ -58,10 +94,10 @@ module Annealing
       global_state_changer.verify
     end
 
-    def test_can_override_the_global_energy_calculator_and_state_change_method
+    def test_can_override_global_energy_calculator_and_state_change_functions
       local_energy_calculator = MiniTest::Mock.new
       local_state_changer = MiniTest::Mock.new
-      (@total_iterations + 1).times do
+      @total_iterations.times do
         local_energy_calculator.expect(:call, 42, [@collection])
         local_state_changer.expect(:call, @collection, [@collection])
       end
@@ -77,60 +113,6 @@ module Annealing
                                    state_change: local_state_changer)
       local_energy_calculator.verify
       local_state_changer.verify
-    end
-
-    def test_uses_the_global_termination_condition_function_if_set
-      global_termination_condition = MiniTest::Mock.new
-      (@total_iterations + 1).times do |i|
-        current_temp = @temperature - (@cooling_rate * i)
-        global_termination_condition.expect(:call, false,
-                                            [@collection, 42, current_temp])
-      end
-
-      Annealing.configure do |config|
-        config.termination_condition = global_termination_condition
-      end
-
-      Annealing::Simulator.new.run(@collection)
-      global_termination_condition.verify
-    end
-
-    def test_can_override_the_global_termination_condition
-      local_termination_condition = MiniTest::Mock.new
-      (@total_iterations + 1).times do |i|
-        current_temp = @temperature - (@cooling_rate * i)
-        local_termination_condition.expect(:call, false,
-                                           [@collection, 42, current_temp])
-      end
-
-      Annealing.configure do |config|
-        config.termination_condition = MiniTest::Mock.new
-      end
-
-      simulator = Annealing::Simulator.new
-      simulator.run(@collection,
-                    termination_condition: local_termination_condition)
-      local_termination_condition.verify
-    end
-
-    def test_returns_early_if_termination_condition_is_met
-      global_energy_calculator = MiniTest::Mock.new
-      @total_iterations = 1 # We'll exit after the temp drops 1 step
-      (@total_iterations + 1).times do
-        global_energy_calculator.expect(:call, 42, [@collection])
-      end
-
-      global_termination_condition = lambda do |_state, _energy, temp|
-        temp == @temperature - 1
-      end
-
-      Annealing.configure do |config|
-        config.energy_calculator = global_energy_calculator
-        config.termination_condition = global_termination_condition
-      end
-
-      Annealing::Simulator.new.run(@collection)
-      global_energy_calculator.verify
     end
   end
 end

--- a/test/annealing_test.rb
+++ b/test/annealing_test.rb
@@ -18,7 +18,7 @@ class AnnealingTest < Minitest::Test
     collection = (1..10).to_a.shuffle
     global_energy_calculator = MiniTest::Mock.new
     global_state_changer = MiniTest::Mock.new
-    (total_iterations + 1).times do
+    total_iterations.times do
       global_energy_calculator.expect(:call, 42, [collection])
       global_state_changer.expect(:call, collection, [collection])
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'annealing'
+require 'debug'
 require 'minitest/autorun'
 require 'ruby-prof'
 


### PR DESCRIPTION
## What

Adds a custom cool down function as outline in #1.

Closes #1 

## Why

`Simulator#cool_down` provides a linear temperature reduction algorithm, but simulated annealing is not always linear. There are allowances in the definition for raising, lowering, and holding the temperature until certain conditions are met. It would be useful to provide a way to specify a custom cooling method that takes the current `energy`, `temperature`, and number of `steps` the algorithm has performed so far, and returns the new temperature, such that it could operate linearly, geometrically, exponentially, or based on some other custom formula with the current state in mind. It would use the linear `Simulator#cool_down` as the default.

## How

- Adds a new `cool_down` configuration option which defaults to a linear reduction function
- Updates `Annealing::Simulator` to call either the global `cool_down` method or one passes in at run time
- Refactors some tests to exercise their scenarios more directly.